### PR TITLE
Changes for v1.2.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,16 +66,11 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
     
     # This prevents errors when automatically installing SDK.
-    # CodeQL does not install .NET 5.0 nor 6.0.    
-    - name: Setup .NET 5.0 SDK+Runtime
+    # CodeQL does not install .NET 8.0.    
+    - name: Setup .NET 8.0 SDK+Runtime
       uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: 5.0.404
-        
-    - name: Setup .NET 6.0 SDK+Runtime
-      uses: actions/setup-dotnet@v1.7.2
-      with:
-        dotnet-version: 6.0.101
+        dotnet-version: 8.0.100
     
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,7 +57,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -75,7 +75,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -89,4 +89,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/netcore_and_netframework.yml
+++ b/.github/workflows/netcore_and_netframework.yml
@@ -40,20 +40,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       
-      - name: Setup .NET Core SDK+Runtime
+      - name: Setup .NET 8.0 SDK+Runtime
         uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: 3.1.x
-          
-      - name: Setup .NET 5.0 SDK+Runtime
-        uses: actions/setup-dotnet@v1.7.2
-        with:
-          dotnet-version: 5.0.404
-          
-      - name: Setup .NET 6.0 SDK+Runtime
-        uses: actions/setup-dotnet@v1.7.2
-        with:
-          dotnet-version: 6.0.101
+          dotnet-version: 8.0.100
         
       - name: Setup MSBuild for .NET Framework
         uses: microsoft/setup-msbuild@v1

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, spassarop
+Copyright (c) 2023, spassarop
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/OWASP.AntiSamy/AntiSamyPolicyExamples/antisamy-anythinggoes.xml
+++ b/OWASP.AntiSamy/AntiSamyPolicyExamples/antisamy-anythinggoes.xml
@@ -41,7 +41,7 @@ http://www.w3.org/TR/html401/struct/global.html
 
 		<regexp name="anything" value=".*"/>
 		<regexp name="numberOrPercent" value="(\d)+(%{0,1})"/>
-		<regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)]|&amp;[0-9]{2};)*"/>
+		<regexp name="paragraph" value="[\p{L}\p{N},'.\s\-_\(\)&amp;;]*"/>
 		<regexp name="htmlId" value="[a-zA-Z0-9\:\-_\.]+"/>
 		<regexp name="htmlTitle" value="[\p{L}\p{N}\s\-_',:\[\]!\./\\\(\)&amp;]*"/> <!-- force non-empty with a '+' at the end instead of '*' -->
 		<regexp name="htmlClass" value="[a-zA-Z0-9\s,\-_]+"/>

--- a/OWASP.AntiSamy/AntiSamyPolicyExamples/antisamy-ebay.xml
+++ b/OWASP.AntiSamy/AntiSamyPolicyExamples/antisamy-ebay.xml
@@ -39,7 +39,7 @@ http://www.w3.org/TR/html401/struct/global.html
 
 		<regexp name="anything" value=".*"/>
 		<regexp name="numberOrPercent" value="(\d)+(%{0,1})"/>
-		<regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)]|&amp;[0-9]{2};)*"/>
+		<regexp name="paragraph" value="[\p{L}\p{N},'.\s\-_\(\)&amp;;]*"/>
 		<regexp name="htmlId" value="[a-zA-Z0-9\:\-_\.]+"/>
 		<regexp name="htmlTitle" value="[\p{L}\p{N}\s\-_',:\[\]!\./\\\(\)&amp;]*"/> <!-- force non-empty with a '+' at the end instead of '*' -->
 		<regexp name="htmlClass" value="[a-zA-Z0-9\s,\-_]+"/>

--- a/OWASP.AntiSamy/AntiSamyPolicyExamples/antisamy-myspace.xml
+++ b/OWASP.AntiSamy/AntiSamyPolicyExamples/antisamy-myspace.xml
@@ -41,7 +41,7 @@ http://www.w3.org/TR/html401/struct/global.html
 
 		<regexp name="anything" value=".*"/>
 		<regexp name="numberOrPercent" value="(\d)+(%{0,1})"/>
-		<regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)]|&amp;[0-9]{2};)*"/>
+		<regexp name="paragraph" value="[\p{L}\p{N},'.\s\-_\(\)&amp;;]*"/>
 		<regexp name="htmlId" value="[a-zA-Z0-9\:\-_\.]+"/>
 		<regexp name="htmlTitle" value="[\p{L}\p{N}\s\-_',:\[\]!\./\\\(\)&amp;]*"/> <!-- force non-empty with a '+' at the end instead of '*' -->
 		<regexp name="htmlClass" value="[a-zA-Z0-9\s,\-_]+"/>

--- a/OWASP.AntiSamy/AntiSamyPolicyExamples/antisamy.xml
+++ b/OWASP.AntiSamy/AntiSamyPolicyExamples/antisamy.xml
@@ -44,7 +44,7 @@ http://www.w3.org/TR/html401/struct/global.html
 
 		<regexp name="anything" value=".*"/>
 		<regexp name="numberOrPercent" value="(\d)+(%{0,1})"/>
-		<regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)]|&amp;[0-9]{2};)*"/>
+		<regexp name="paragraph" value="[\p{L}\p{N},'.\s\-_\(\)&amp;;]*"/>
 		<regexp name="htmlId" value="[a-zA-Z0-9\:\-_\.]+"/>
 		<regexp name="htmlTitle" value="[\p{L}\p{N}\s\-_',:\[\]!\./\\\(\)&amp;]*"/>
 		<!-- force non-empty with a '+' at the end instead of '*' -->

--- a/OWASP.AntiSamy/Css/CssScanner.cs
+++ b/OWASP.AntiSamy/Css/CssScanner.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Jerry Hoff, Caner Patir, Sebasti·n Passaro
+ * Copyright (c) 2023, Jerry Hoff, Caner Patir, Sebasti√°n Passaro
  * 
  * 
  * All rights reserved.

--- a/OWASP.AntiSamy/Exceptions/ParseException.cs
+++ b/OWASP.AntiSamy/Exceptions/ParseException.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Caner Patir, Sebasti·n Passaro
+ * Copyright (c) 2023, Caner Patir, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Exceptions/PolicyException.cs
+++ b/OWASP.AntiSamy/Exceptions/PolicyException.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebasti·n Passaro
+ * Copyright (c) 2008-2023, Jerry Hoff, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Exceptions/ScanException.cs
+++ b/OWASP.AntiSamy/Exceptions/ScanException.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebasti·n Passaro
+ * Copyright (c) 2008-2023, Jerry Hoff, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Exceptions/UnknownSelectorException.cs
+++ b/OWASP.AntiSamy/Exceptions/UnknownSelectorException.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2009-2022, Sebastián Passaro
+ * Copyright (c) 2009-2023, Sebastián Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/AntiSamy.cs
+++ b/OWASP.AntiSamy/Html/AntiSamy.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebasti·n Passaro
+ * Copyright (c) 2008-2023, Jerry Hoff, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/CleanResults.cs
+++ b/OWASP.AntiSamy/Html/CleanResults.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebastián Passaro
+ * Copyright (c) 2008-2023, Jerry Hoff, Sebastián Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/CleanResults.cs
+++ b/OWASP.AntiSamy/Html/CleanResults.cs
@@ -33,24 +33,27 @@ namespace OWASP.AntiSamy.Html
     /// HTML, per the AntiSamy sanitization policy applied. It also provides access to some utility
     /// information, like possible error messages and error message counts.
     ///
-    /// <p>WARNING: The ONLY output from the class you can completely rely on is the CleanResults output.
-    /// As stated in the README, the getErrorMessages() method does not subtly answer the question "is
-    /// this safe input?" in the affirmative if it returns an empty list. You must always use the
-    /// sanitized 'Clean' input and there is no way to be sure the input passed in had no attacks.
+    /// <para>WARNING: The ONLY output from the class you can completely rely on is the CleanResults output.
+    /// As stated in the documentation, neither the <see cref="GetErrorMessages"/> nor the <see cref="GetNumberOfErrors"/> methods
+    /// subtly answer the question "is this safe input?" in the affirmative if it returns an empty list. 
+    /// You must always use the sanitized 'Clean' input and there is no way to be sure the input passed in had no attacks.
+    /// </para>
     ///
-    /// <p>The serialization and deserialization process that is critical to the effectiveness of the
+    /// <para>The serialization and deserialization process that is critical to the effectiveness of the
     /// sanitizer is purposefully lossy and will filter out attacks via a number of attack vectors.
     /// Unfortunately, one of the tradeoffs of this strategy is that AntiSamy doesn't always know in
-    /// retrospect that an attack was seen. Thus, the getErrorMessages() API is there to help users
+    /// retrospect that an attack was seen. Thus, the <see cref="GetErrorMessages"/> API is there to help users
     /// understand whether their well-intentioned input meets the requirements of the system, not help a
     /// developer detect if an attack was present.
+    /// </para>
     ///
-    /// The list of error messages (<see cref="GetErrorMessages"/>) will let the user know what, if any
+    /// <para>The list of error messages (<see cref="errorMessages"/>) will let the user know what, if any
     /// HTML errors existed, and what, if any, security or validation-related errors were detected, and
     /// what was done about them. NOTE: As just stated, the absence of error messages does NOT mean there
-    /// were no attacks in the input that was sanitized out. You CANNOT rely on the errorMessages to tell
-    /// you if the input was dangerous. You MUST use the output of getCleanHTML() to ensure your output
+    /// were no attacks in the input that was sanitized out. You CANNOT rely on the <see cref="errorMessages"/> to tell
+    /// you if the input was dangerous. You MUST use the output of <see cref="GetCleanHtml"/> to ensure your output
     /// is safe.
+    /// </para>
     /// </summary>
     public class CleanResults
     {
@@ -91,11 +94,17 @@ namespace OWASP.AntiSamy.Html
         /// <param name="cleanHtml"></param>
         public void SetCleanHtml(string cleanHtml) => this.cleanHtml = cleanHtml;
 
-        /// <summary> Return the filtered HTML as a string.</summary>
+        /// <summary> 
+        /// Return the filtered HTML as a string. This output is the ONLY output you can trust to be safe.
+        /// The absence of error messages does NOT indicate the input was safe.
+        /// </summary>
         /// <returns> A string object which contains the serialized, safe HTML.</returns>
         public string GetCleanHtml() => cleanHtml;
 
-        /// <summary> Return a list of error messages.</summary>
+        /// <summary> 
+        /// Return a list of error messages -- but an empty list returned does not mean there was no attack
+        /// present, due to the serialization and deserialization process automatically cleaning up some attacks.
+        /// </summary>
         /// <returns> A <see cref="List{String}"/> object which contains the error messages after a scan.</returns>
         public List<string> GetErrorMessages() => errorMessages;
 
@@ -117,7 +126,7 @@ namespace OWASP.AntiSamy.Html
 
         /// <summary> 
         /// Return the number of errors encountered during filtering. Note that 0 errors does NOT
-        /// mean the input was safe. Only the output of getCleanHTML() can be considered safe.
+        /// mean the input was safe. Only the output of <see cref="GetCleanHtml"/> can be considered safe.
         /// </summary>
         public int GetNumberOfErrors() => errorMessages.Count;
     }

--- a/OWASP.AntiSamy/Html/CleanResults.cs
+++ b/OWASP.AntiSamy/Html/CleanResults.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebasti·n Passaro
+ * Copyright (c) 2008-2022, Jerry Hoff, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 
@@ -29,11 +29,28 @@ using System.Xml;
 namespace OWASP.AntiSamy.Html
 {
     /// <summary> 
-    /// This class contains the results of a scan.
-    /// 
-    /// The list of error messages (<see cref="GetErrorMessages"/>) will let the user know
-    /// what, if any HTML errors existed, and what, if any, security or
-    /// validation-related errors existed, and what was done about them.
+    /// This class contains the results of a scan. It primarily provides access to the clean sanitized
+    /// HTML, per the AntiSamy sanitization policy applied. It also provides access to some utility
+    /// information, like possible error messages and error message counts.
+    ///
+    /// <p>WARNING: The ONLY output from the class you can completely rely on is the CleanResults output.
+    /// As stated in the README, the getErrorMessages() method does not subtly answer the question "is
+    /// this safe input?" in the affirmative if it returns an empty list. You must always use the
+    /// sanitized 'Clean' input and there is no way to be sure the input passed in had no attacks.
+    ///
+    /// <p>The serialization and deserialization process that is critical to the effectiveness of the
+    /// sanitizer is purposefully lossy and will filter out attacks via a number of attack vectors.
+    /// Unfortunately, one of the tradeoffs of this strategy is that AntiSamy doesn't always know in
+    /// retrospect that an attack was seen. Thus, the getErrorMessages() API is there to help users
+    /// understand whether their well-intentioned input meets the requirements of the system, not help a
+    /// developer detect if an attack was present.
+    ///
+    /// The list of error messages (<see cref="GetErrorMessages"/>) will let the user know what, if any
+    /// HTML errors existed, and what, if any, security or validation-related errors were detected, and
+    /// what was done about them. NOTE: As just stated, the absence of error messages does NOT mean there
+    /// were no attacks in the input that was sanitized out. You CANNOT rely on the errorMessages to tell
+    /// you if the input was dangerous. You MUST use the output of getCleanHTML() to ensure your output
+    /// is safe.
     /// </summary>
     public class CleanResults
     {
@@ -98,7 +115,10 @@ namespace OWASP.AntiSamy.Html
         /// <param name="msg">An error message to append to the list of aggregate error messages during filtering.</param>
         public void AddErrorMessage(string msg) => errorMessages.Add(msg);
 
-        /// <summary> Return the number of errors encountered during filtering.</summary>
+        /// <summary> 
+        /// Return the number of errors encountered during filtering. Note that 0 errors does NOT
+        /// mean the input was safe. Only the output of getCleanHTML() can be considered safe.
+        /// </summary>
         public int GetNumberOfErrors() => errorMessages.Count;
     }
 }

--- a/OWASP.AntiSamy/Html/InternalPolicy.cs
+++ b/OWASP.AntiSamy/Html/InternalPolicy.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Kristian Rosenvold, Sebasti·n Passaro
+ * Copyright (c) 2008-2023, Kristian Rosenvold, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/Model/AntiSamyPattern.cs
+++ b/OWASP.AntiSamy/Html/Model/AntiSamyPattern.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebasti·n Passaro
+ * Copyright (c) 2008-2023, Jerry Hoff, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/Model/Attribute.cs
+++ b/OWASP.AntiSamy/Html/Model/Attribute.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebasti·n Passaro
+ * Copyright (c) 2008-2023, Jerry Hoff, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/Model/Property.cs
+++ b/OWASP.AntiSamy/Html/Model/Property.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebasti·n Passaro
+ * Copyright (c) 2008-2023, Jerry Hoff, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/Model/Tag.cs
+++ b/OWASP.AntiSamy/Html/Model/Tag.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebasti·n Passaro
+ * Copyright (c) 2008-2023, Jerry Hoff, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/ParseContext.cs
+++ b/OWASP.AntiSamy/Html/ParseContext.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007-2022, Arshan Dabirsiaghi, Jason Li, Kristian Rosenvold, Sebasti·n Passaro
+ * Copyright (c) 2007-2023, Arshan Dabirsiaghi, Jason Li, Kristian Rosenvold, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/Policy.cs
+++ b/OWASP.AntiSamy/Html/Policy.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebastián Passaro
+ * Copyright (c) 2008-2023, Jerry Hoff, Sebastián Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/Scan/AntiSamyDomScanner.cs
+++ b/OWASP.AntiSamy/Html/Scan/AntiSamyDomScanner.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022, Jerry Hoff, Sebasti·n Passaro
+ * Copyright (c) 2009-2023, Jerry Hoff, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/Scan/AntiSamyDomScanner.cs
+++ b/OWASP.AntiSamy/Html/Scan/AntiSamyDomScanner.cs
@@ -136,7 +136,7 @@ namespace OWASP.AntiSamy.Html.Scan
 
             // All the cleaned HTML
             string finalCleanHTML = Policy.PreservesSpace ? htmlDocument.DocumentNode.InnerHtml : htmlDocument.DocumentNode.InnerHtml.Trim();
-
+            
             // Encode special/international characters if stated by policy
             if (Policy.EntityEncodesInternationalCharacters)
             {
@@ -369,6 +369,15 @@ namespace OWASP.AntiSamy.Html.Scan
             if (tagName.ToLowerInvariant() == "style" && Policy.GetTagByName("style") != null && !ProcessStyleTag(node, parentNode))
             {
                 return;
+            }
+
+            /*
+            * Parse every <noscript> node content as plain text by replacing its content with its transformation.
+            * Covers a case when preserving comments and how the underlying parser works, where a bug arises.
+            */
+            if (tagName.ToLowerInvariant() == "noscript" && Policy.PreservesComments)
+            {
+                node.ParentNode.ReplaceChild(parentNode.OwnerDocument.CreateTextNode(node.InnerText), node);
             }
 
             /*

--- a/OWASP.AntiSamy/Html/Scan/Constants.cs
+++ b/OWASP.AntiSamy/Html/Scan/Constants.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebastián Passaro
+ * Copyright (c) 2008-2023, Jerry Hoff, Sebastián Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/TagMatcher.cs
+++ b/OWASP.AntiSamy/Html/TagMatcher.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2022, Kristian Rosenvold, Sebasti·n Passaro
+ * Copyright (c) 2013-2023, Kristian Rosenvold, Sebasti√°n Passaro
  *
  * All rights reserved.
  *

--- a/OWASP.AntiSamy/Html/Util/DictionaryExtensions.cs
+++ b/OWASP.AntiSamy/Html/Util/DictionaryExtensions.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sebasti·n Passaro
+ * Copyright (c) 2023, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/Util/ErrorMessageUtil.cs
+++ b/OWASP.AntiSamy/Html/Util/ErrorMessageUtil.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sebasti·n Passaro
+ * Copyright (c) 2023, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/Util/HtmlEntityEncoder.cs
+++ b/OWASP.AntiSamy/Html/Util/HtmlEntityEncoder.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebasti·n Passaro
+ * Copyright (c) 2008-2023, Jerry Hoff, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/Util/PolicyParserUtil.cs
+++ b/OWASP.AntiSamy/Html/Util/PolicyParserUtil.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Arshan Dabirsiaghi, Jason Li, Kristian Rosenvold, Sebasti·n Passaro
+ * Copyright (c) 2008-2023, Arshan Dabirsiaghi, Jason Li, Kristian Rosenvold, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/Util/SpecialCharactersEncoder.cs
+++ b/OWASP.AntiSamy/Html/Util/SpecialCharactersEncoder.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sebasti·n Passaro
+ * Copyright (c) 2023, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/Html/Util/XmlUtil.cs
+++ b/OWASP.AntiSamy/Html/Util/XmlUtil.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Jerry Hoff, Sebasti·n Passaro
+ * Copyright (c) 2008-2023, Jerry Hoff, Sebasti√°n Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamy/OWASP.AntiSamy.csproj
+++ b/OWASP.AntiSamy/OWASP.AntiSamy.csproj
@@ -11,7 +11,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Authors>spassaro</Authors>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <Copyright>Copyright © 2022 - Arshan Dabirsiaghi, Sebastián Passaro</Copyright>
+    <Copyright>Copyright © 2023 - Arshan Dabirsiaghi, Sebastián Passaro</Copyright>
     <Description>A library for performing fast, configurable cleansing of HTML coming from untrusted sources.
     
 Another way of saying that could be: It's an API that helps you make sure that clients don't supply malicious cargo code in the HTML they supply for their profile, comments, etc., that get persisted on the server. The term "malicious code" in regard to web applications usually mean "JavaScript." Mostly, Cascading Stylesheets are only considered malicious when they invoke JavaScript. However, there are many situations where "normal" HTML and CSS can be used in a malicious manner.</Description>

--- a/OWASP.AntiSamy/OWASP.AntiSamy.csproj
+++ b/OWASP.AntiSamy/OWASP.AntiSamy.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.0;netcoreapp3.1;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net48</TargetFrameworks>
     <StartupObject></StartupObject>
     <OldToolsVersion>3.5</OldToolsVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -22,9 +22,9 @@ Another way of saying that could be: It's an API that helps you make sure that c
     <DefineConstants>NET5_0</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.16.1" />
-    <PackageReference Include="AngleSharp.Css" Version="0.16.4" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
+    <PackageReference Include="AngleSharp" Version="0.17.1" />
+    <PackageReference Include="AngleSharp.Css" Version="0.17.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.55" />
   </ItemGroup>
   <ItemGroup>
     <!-- Added so NuGet copies this folder to the output package -->

--- a/OWASP.AntiSamy/OWASP.AntiSamy.csproj
+++ b/OWASP.AntiSamy/OWASP.AntiSamy.csproj
@@ -17,20 +17,12 @@
 Another way of saying that could be: It's an API that helps you make sure that clients don't supply malicious cargo code in the HTML they supply for their profile, comments, etc., that get persisted on the server. The term "malicious code" in regard to web applications usually mean "JavaScript." Mostly, Cascading Stylesheets are only considered malicious when they invoke JavaScript. However, there are many situations where "normal" HTML and CSS can be used in a malicious manner.</Description>
     <Title>OWASP.AntiSamy</Title>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0'">
-    <DefineConstants>NET5_0</DefineConstants>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.17.1" />
     <PackageReference Include="AngleSharp.Css" Version="0.17.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.55" />
-  </ItemGroup>
-  <ItemGroup>
-    <!-- Added so NuGet copies this folder to the output package -->
-    <Content Include="AntiSamyPolicyExamples\**\*">
-      <CopyToPublishDirectory>true</CopyToPublishDirectory>
-    </Content>
   </ItemGroup>
   <ItemGroup>
     <None Update="AntiSamyPolicyExamples\antisamy-anythinggoes.xml">
@@ -57,6 +49,7 @@ Another way of saying that could be: It's an API that helps you make sure that c
     <None Update="AntiSamyPolicyExamples\antisamy.xsd">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/OWASP.AntiSamy/Properties/AssemblyInfo.cs
+++ b/OWASP.AntiSamy/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("spassaro")]
 [assembly: AssemblyProduct("AntiSamy")]
-[assembly: AssemblyCopyright("Copyright © 2022 - Arshan Dabirsiaghi, Sebastián Passaro")]
+[assembly: AssemblyCopyright("Copyright © 2023 - Arshan Dabirsiaghi, Sebastián Passaro")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/OWASP.AntiSamyTests/Html/AntiSamyTest.cs
+++ b/OWASP.AntiSamyTests/Html/AntiSamyTest.cs
@@ -903,6 +903,10 @@ namespace AntiSamyTests
                 .Should().NotContain("script");
             antisamy.Scan("<select<style/>k<input<</>input/onfocus=alert(1)>", policy).GetCleanHtml()
                 .Should().NotContain("input");
+            antisamy.Scan("<style/><listing/>]]><noembed></style><img src=x onerror=mxss(1)></noembed>", policy).GetCleanHtml()
+               .Should().NotContain("mxss");
+            antisamy.Scan("<style/><math>'<noframes ></style><img src=x onerror=mxss(1)></noframes>'", policy).GetCleanHtml()
+               .Should().NotContain("mxss");
         }
 
         [Test]

--- a/OWASP.AntiSamyTests/Html/AntiSamyTest.cs
+++ b/OWASP.AntiSamyTests/Html/AntiSamyTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2009-2022, Arshan Dabirsiaghi, Sebastián Passaro
+ * Copyright (c) 2009-2023, Arshan Dabirsiaghi, Sebastián Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamyTests/Html/LiteralTest.cs
+++ b/OWASP.AntiSamyTests/Html/LiteralTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2009-2022, Arshan Dabirsiaghi, Sebastián Passaro
+ * Copyright (c) 2009-2023, Arshan Dabirsiaghi, Sebastián Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamyTests/Html/LocalizationTest.cs
+++ b/OWASP.AntiSamyTests/Html/LocalizationTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2022, Sebastián Passaro
+ * Copyright (c) 2023, Sebastián Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamyTests/Html/Model/TagTest.cs
+++ b/OWASP.AntiSamyTests/Html/Model/TagTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2013-2022, Kristian Rosenvold, Sebastián Passaro
+ * Copyright (c) 2013-2023, Kristian Rosenvold, Sebastián Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamyTests/Html/PolicyTest.cs
+++ b/OWASP.AntiSamyTests/Html/PolicyTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2009-2022, Arshan Dabirsiaghi, Sebastián Passaro
+ * Copyright (c) 2009-2023, Arshan Dabirsiaghi, Sebastián Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamyTests/Html/TagMatcherTest.cs
+++ b/OWASP.AntiSamyTests/Html/TagMatcherTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2013-2022, Kristian Rosenvold, Sebastián Passaro
+ * Copyright (c) 2013-2023, Kristian Rosenvold, Sebastián Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamyTests/OWASP.AntiSamyTests.csproj
+++ b/OWASP.AntiSamyTests/OWASP.AntiSamyTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <Copyright>Copyright © 2022 - Arshan Dabirsiaghi, Sebastián Passaro</Copyright>
+    <Copyright>Copyright © 2023 - Arshan Dabirsiaghi, Sebastián Passaro</Copyright>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <Description>Tests project for OWASP AntiSamy .NET.</Description>
   </PropertyGroup>

--- a/OWASP.AntiSamyTests/OWASP.AntiSamyTests.csproj
+++ b/OWASP.AntiSamyTests/OWASP.AntiSamyTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net46</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Copyright>Copyright © 2022 - Arshan Dabirsiaghi, Sebastián Passaro</Copyright>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 

--- a/OWASP.AntiSamyTests/TestConstants.cs
+++ b/OWASP.AntiSamyTests/TestConstants.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2022, Sebastián Passaro
+ * Copyright (c) 2023, Sebastián Passaro
  * 
  * All rights reserved.
  * 

--- a/OWASP.AntiSamyTests/TestPolicy.cs
+++ b/OWASP.AntiSamyTests/TestPolicy.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2022, Sebastián Passaro
+ * Copyright (c) 2023, Sebastián Passaro
  * 
  * All rights reserved.
  * 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This project will be trying to be in sync with the original Java version, its re
 
 Check the [wiki](https://github.com/spassarop/antisamy-dotnet/wiki) for information on how to use, build, test and more.
 
+**Important note**: Since 1.2.0 the example policy files that were previously included in the NuGet package are removed. Each developer/deployer must manually place a policy in a location of their choice. For mor information about policies, refer to the wiki mentioned above.
+
 ## Contributing to OWASP AntiSamy .NET
 
 ### Found an issue?


### PR DESCRIPTION
- Improved code documentation regarding methods for testing policies.
- Fix bug regarding `noscript` when preserving comments in the policy.
- Updated `paragraph` regex in example policies.
- Changed project to exclude the example policies from being added to the NuGet package (#11).
- Changed target frameworks to include only [the ones covered by .NET Standard 2.0](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0).
- Updated versions for GitHub actions.
- Added more tests.